### PR TITLE
Require a POST to show password

### DIFF
--- a/finger/static/fingerweb.scss
+++ b/finger/static/fingerweb.scss
@@ -52,3 +52,7 @@ body {
 	flex-grow: 1;
     }
 }
+
+form {
+    display: inline-block;
+}

--- a/services/templates/services/service.html
+++ b/services/templates/services/service.html
@@ -9,6 +9,9 @@
 <p>{{user}} has an account for this service.</p>
 {% if secret %}
 <p>Your password is "<code>{{secret}}</code>".</p>
+<script type="text/javascript">
+  window.history.pushState({}, document.title, document.location);
+</script>
 <form method="get"><button>Hide password</button></form>
 {% else %}
 <form method="post">{% csrf_token %}

--- a/services/templates/services/service.html
+++ b/services/templates/services/service.html
@@ -9,8 +9,11 @@
 <p>{{user}} has an account for this service.</p>
 {% if secret %}
 <p>Your password is "<code>{{secret}}</code>".</p>
+<form method="get"><button>Hide password</button></form>
 {% else %}
-<p><a href="?show-secret=t">Show password</a></p>
+<form method="post">{% csrf_token %}
+  <button name="action" value="show">Show password</button>
+</form>
 {% endif %}
 <form method="post">{% csrf_token %}
   <button name="action" value="generate">Reset password</button>

--- a/services/views.py
+++ b/services/views.py
@@ -5,14 +5,14 @@ from .models import Service
 # Create your views here.
 def service(request, name):
     service = get_object_or_404(Service, name=name)
-    if request.POST.get('action') == 'generate':
+    action = request.POST.get('action')
+    show_secret = action in ('generate', 'show')
+    if action == 'generate':
         service.generate_password(request.user)
-        return redirect(request.path + "?show-secret=t")
-    else:
-        account = service.account_for(request.user)
-        show_secret = request.GET.get('show-secret')
-        return render(request, 'services/service.html', {
-            'service': service,
-            'has_account': account and True,
-            'secret': show_secret and account and account.secret,
-        })
+
+    account = service.account_for(request.user)
+    return render(request, 'services/service.html', {
+        'service': service,
+        'has_account': account and True,
+        'secret': show_secret and account and account.secret,
+    })


### PR DESCRIPTION
Just adding a query-string to a GET url to get the password might be insecure (hostile javascript could use a users credentials).  Requiering a POST, which requires a CSRF  value, should be safer.