### PR TITLE
Link to root url from logged out template

### DIFF
--- a/finger/templates/registration/logged_out.html
+++ b/finger/templates/registration/logged_out.html
@@ -7,6 +7,6 @@
 
 <p>{% trans "Thanks for spending some quality time with the Web site today." %}</p>
 
-<p><a href="{% url 'admin:index' %}">{% trans 'Log in again' %}</a></p>
+<p><a href="{% url 'index' %}">{% trans 'Log in again' %}</a></p>
 
 {% endblock %}


### PR DESCRIPTION
When logging out as a non-admin user, there is a link saying "log in
again". That is nice, but that link currently directs the user to
`/login?next=/admin`, which is not optimal for the standard, non-admin
user.