### PR TITLE
Extract staff or superuser required decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ export DJANGOADMIN_PASSWORD=password
 ./manage.py
 ```
 
+## Run tests
+
+If you are working locally:
+
+``` python
+pip install pytest-django
+pytest
+```
+
 ## Production build
 
 A image is built and published to Docker Hub at `stacken/fingerweb:tag` where

--- a/finger/decorators.py
+++ b/finger/decorators.py
@@ -1,0 +1,29 @@
+"""
+A module to collect custom decorators that we use throughout fingerweb.
+"""
+
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseForbidden
+from django.utils.functional import wraps
+
+
+def staff_or_superuser_required(view):
+    """
+    Require a logged in user that is both staff _and_ a superuser.
+
+    Usage:
+
+        from fingerweb.decorators import staff_or_superuser_required
+
+        @staff_or_superuser_required
+        def my_view(request): ...
+    """
+    @login_required
+    @wraps(view)
+    def inner(request, *args, **kwargs):
+        if not (request.user.is_staff and request.user.is_superuser):
+            return HttpResponseForbidden()
+
+        return view(request, *args, **kwargs)
+
+    return inner

--- a/finger/tests/test_decorators.py
+++ b/finger/tests/test_decorators.py
@@ -1,0 +1,31 @@
+import pytest
+from django.http import HttpResponse
+from django.test import RequestFactory
+from finger.models import User
+from finger.decorators import staff_or_superuser_required
+
+
+@pytest.mark.parametrize(
+    "is_staff,is_superuser,expected_response_code",
+    (
+        (False, False, 403),
+        (True, False, 403),
+        (False, True, 403),
+        (True, True, 200),
+    )
+)
+def test_staff_or_superuser__only_allows_staff_superusers(
+        is_staff, is_superuser, expected_response_code
+):
+    @staff_or_superuser_required
+    def some_test_view(_request):
+        return HttpResponse("All is ok")
+
+    user = User(is_staff=is_staff, is_superuser=is_superuser)
+
+    request = RequestFactory().get('/some-test-view')
+    request.user = user
+
+    response = some_test_view(request)
+
+    assert response.status_code == expected_response_code

--- a/finger/urls.py
+++ b/finger/urls.py
@@ -7,4 +7,3 @@ urlpatterns = [
     path('upload', views.upload_json),
     path('mail_members', views.mail_members)
 ]
-

--- a/finger/views.py
+++ b/finger/views.py
@@ -1,14 +1,15 @@
 import sys
 
-from django.contrib.auth import views  as ca_views
+from django.contrib.auth import views as ca_views
 from django.contrib.auth.decorators import login_required
+from django.core.mail import send_mass_mail
 from django.db import transaction
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
-from django.core.mail import send_mass_mail
 from finger.decorators import staff_or_superuser_required
 from services.models import Service
-from .forms import PasswordResetForm, UploadFileForm, MailMembersForm
+
+from .forms import MailMembersForm, PasswordResetForm, UploadFileForm
 from .models import User
 
 

--- a/finger/views.py
+++ b/finger/views.py
@@ -3,9 +3,10 @@ import sys
 from django.contrib.auth import views  as ca_views
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
-from django.http import HttpResponseRedirect, HttpResponseNotAllowed
+from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.core.mail import send_mass_mail
+from finger.decorators import staff_or_superuser_required
 from services.models import Service
 from .forms import PasswordResetForm, UploadFileForm, MailMembersForm
 from .models import User
@@ -17,10 +18,8 @@ def index(request):
         'services': Service.objects.all()
     })
 
-@login_required
+@staff_or_superuser_required
 def upload_json(request):
-    if not (request.user.is_staff and request.user.is_superuser):
-        return HttpResponseNotAllowed()
     if request.method == 'POST':
         form = UploadFileForm(request.POST, request.FILES)
         if form.is_valid():
@@ -33,11 +32,8 @@ def upload_json(request):
         'form': form,
     })
 
-@login_required
+@staff_or_superuser_required
 def mail_members(request):
-    if not (request.user.is_staff and request.user.is_superuser):
-        return HttpResponseNotAllowed()
-
     if request.method == 'POST':
         form = MailMembersForm(request.POST)
     else:

--- a/services/views.py
+++ b/services/views.py
@@ -1,9 +1,11 @@
 from base64 import b64decode
 from datetime import datetime
+
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.hashers import check_password
-from django.http import JsonResponse, HttpResponseForbidden
-from django.shortcuts import get_object_or_404, redirect, render
+from django.http import HttpResponseForbidden, JsonResponse
+from django.shortcuts import get_object_or_404, render
+
 from .models import Service
 
 @login_required

--- a/services/views.py
+++ b/services/views.py
@@ -8,6 +8,7 @@ from django.shortcuts import get_object_or_404, render
 
 from .models import Service
 
+
 @login_required
 def service(request, name):
     service = get_object_or_404(Service, name=name)
@@ -22,6 +23,7 @@ def service(request, name):
         'has_account': account and True,
         'secret': show_secret and account and account.secret,
     })
+
 
 def passwords(request, name):
     auth_user, auth_key = basic_auth(request)
@@ -41,6 +43,7 @@ def passwords(request, name):
     return JsonResponse(dict(
         query.values_list('user__username', 'secret')
     ))
+
 
 def basic_auth(request):
     auth_data = request.META.get('HTTP_AUTHORIZATION')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[tool:pytest]
+DJANGO_SETTINGS_MODULE = fingerweb.settings
+python_files = "test*.py"


### PR DESCRIPTION
Jag bryter ut en liten bit upprepad funktionalitet från finger.views, som jag misstänker att vi kommer kunna återanvända fler gånger, om vi vill ha fler vyer som kräver att man är både staff och superuser för.

Jag lägger också till lite pytest-tester för den, samt tillräckligt mycket config för att de ska gå att köra.

Jag har dock inte riktigt listat ut hur man kan göra för att köra testerna inuti docker. Jag kör fingerweb på min host eftersom jag ändå redan har en bra setup för att köra django-projekt på det sättet.