### PR TITLE
Add missing fields to admin user.

### DIFF
--- a/finger/management/commands/stackenadmin.py
+++ b/finger/management/commands/stackenadmin.py
@@ -4,6 +4,7 @@ from django.db import transaction
 from optparse import make_option
 from finger.models import User
 from os import environ
+from dateutil import parser
 
 
 class Command(BaseCommand):
@@ -15,5 +16,11 @@ class Command(BaseCommand):
             print("No password given.  No admin created")
             return
         User.objects.filter(username="admin").delete()
-        User.objects.create_superuser("admin", "staff@stacken.kth.se", password)
+        User.objects.create_superuser(
+            "admin",
+            "staff@stacken.kth.se",
+            password,
+            is_active=True,
+            date_joined=parser.parse("1970-01-01 00:00:01 CET"),
+        )
         print("Created/updated admin accout")


### PR DESCRIPTION
The admin user had several fields that where null, after the merger of
PR #23 it become apparent that this was not an valid scheme. This PR
will add the minimal needed non-null values to the admin creation.