### PR TITLE
Do no delete an existing admin user

### DIFF
--- a/finger/management/commands/stackenadmin.py
+++ b/finger/management/commands/stackenadmin.py
@@ -15,6 +15,14 @@ class Command(BaseCommand):
         if not password:
             print("No password given. No admin created/updated")
             return
+
+        # Fix for developers, PR #28 fixed an bug where is_active and
+        # data_joined was not set propperly. This code can be removed
+        # in the future.
+        if User.objects.filter(username="admin", is_active=None).exists():
+            print("Admin user needs to be recreated")
+            User.objects.filter(username="admin").delete()
+
         if User.objects.filter(username="admin").exists():
             print("Admin user already exists, update the existing user")
             User.objects.get(username="admin").set_password(password)

--- a/finger/management/commands/stackenadmin.py
+++ b/finger/management/commands/stackenadmin.py
@@ -13,14 +13,17 @@ class Command(BaseCommand):
     def handle(self, **options):
         password = environ.get("DJANGOADMIN_PASSWORD")
         if not password:
-            print("No password given.  No admin created")
+            print("No password given. No admin created/updated")
             return
-        User.objects.filter(username="admin").delete()
-        User.objects.create_superuser(
-            "admin",
-            "staff@stacken.kth.se",
-            password,
-            is_active=True,
-            date_joined=parser.parse("1970-01-01 00:00:01 CET"),
-        )
-        print("Created/updated admin accout")
+        if User.objects.filter(username="admin").exists():
+            print("Admin user already exists, update the existing user")
+            User.objects.get(username="admin").set_password(password)
+        else:
+            print("Create admin accout")
+            User.objects.create_superuser(
+                "admin",
+                "staff@stacken.kth.se",
+                password,
+                is_active=True,
+                date_joined=parser.parse("1970-01-01 00:00:01 CET"),
+            )


### PR DESCRIPTION
The old code always deleted the admin user and re-created a new one.
This had the effect that the user was logged out every single time
(because the user id was removed). This also spammed the database with
user id:s.

The password will be updated if an admin user already exists.