### PR TITLE
Post office

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - DATABASE_URL=psql://postgres:dbpassword@fingerwebdb:5432/fingerweb
       - DEBUG=True
       - DJANGOADMIN_PASSWORD=password
+      - EMAIL_HOST=dummy_email_server
     links:
       - fingerwebdb
     volumes:
@@ -22,3 +23,7 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_DB=fingerweb
       - POSTGRES_PASSWORD=dbpassword
+  dummy_email_server:
+    image: python:3
+    command: python3 -u -m smtpd -n -c DebuggingServer 0.0.0.0:25
+    stop_grace_period: 1s

--- a/finger/templates/admin/send_email_confirmation.html
+++ b/finger/templates/admin/send_email_confirmation.html
@@ -1,0 +1,27 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
+
+<h1>Send E-mail to the following users</h1>
+
+<p>
+    By pressing <em>Confirm</em>, you will queue the following E-Mails to be sent out:
+</p>
+
+<ul>
+{% for member in members %}
+<li>{{ member.email }}</li>
+{% endfor %}
+</ul>
+
+<div>
+    <form action="" method="post">
+        {% csrf_token %}
+        {% for member in members %}
+        <input type="hidden" name="_selected_action" value="{{ member.pk }}" />
+        {% endfor %}
+        <input type="hidden" name="action" value="send_email" />
+        <input type="submit" name="apply" value="Confirm" />
+    </form>
+</div>
+{% endblock %}

--- a/fingerweb/settings.py
+++ b/fingerweb/settings.py
@@ -66,7 +66,7 @@ MIDDLEWARE = [
 
 ROOT_URLCONF = "fingerweb.urls"
 
-EMAIL_HOST = "smtp.kth.se"
+EMAIL_HOST = env("EMAIL_HOST", default="smtp.kth.se")
 EMAIL_USE_TLS = False
 
 TEMPLATES = [

--- a/fingerweb/settings.py
+++ b/fingerweb/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 """
 import environ
 import os
+import datetime
 
 ADMINS = (("Stacken", "staff@stacken.kth.se"),)
 MANAGERS = ADMINS
@@ -50,6 +51,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "static_precompiler",
+    "post_office",
     "finger",
     "services",
 ]
@@ -68,6 +70,14 @@ ROOT_URLCONF = "fingerweb.urls"
 
 EMAIL_HOST = env("EMAIL_HOST", default="smtp.kth.se")
 EMAIL_USE_TLS = False
+EMAIL_BACKEND = "post_office.EmailBackend"
+
+POST_OFFICE = {
+    "MESSAGE_ID_ENABLED": True,
+    "MESSAGE_ID_FQDN": "fingerweb.stacken.kth.se",
+    "RETRY_INTERVAL": datetime.timedelta(hours=6),
+    "MAX_RETRIES": 4,
+}
 
 TEMPLATES = [
     {

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ gunicorn ~= 19.9.0
 django-environ ~= 0.4.5
 psycopg2-binary ~= 2.8.3
 python-dateutil ~= 2.8.0
-
+django-post_office ~= 3.5.2


### PR DESCRIPTION
This PR adds [django-post_office](https://github.com/ui/django-post_office) to the project. It's a quite nice way to send emails. It will queue emails in the background and send them in batches. It also has support for templates.

![image](https://user-images.githubusercontent.com/16388/99888561-1f5a1280-2c4e-11eb-9e92-97bc3814237a.png)

I added a simple example how to use it.

I also added a simple debug SMTP server to the docker-compose file for easier debugging.

Love to have some feedback from @Frost, and also ping @olsjo 