### PR TITLE
Make stringified User/Member objects readable

### DIFF
--- a/finger/models.py
+++ b/finger/models.py
@@ -349,6 +349,12 @@ class Member(models.Model):
     def joined_years_ago(self):
         return timezone.now().year - self.date_joined.year
 
+    def __repr__(self):
+        return f"<Member: {self.get_full_name()} ({self.pk})>"
+
+    def __str__(self):
+        return f"{self.get_full_name()} (id: {self.pk})"
+
 
 def parse_date(datestr):
     if datestr:
@@ -368,3 +374,9 @@ class User(AbstractUser):
     member = models.ForeignKey(Member, on_delete=models.CASCADE, null=True, default=None)
 
     objects = UserManager()
+
+    def __repr__(self):
+        return f"<User: {self.username} ({self.pk})>"
+
+    def __str__(self):
+        return f"{self.username} (id: {self.pk})"


### PR DESCRIPTION
When looking at the user admin page, the member select dropdown looks
something like this:

    Member object (1)
    Member object (2)
    Member object (3)
    Member object (4)
    Member object (5)

This is a bit hard to read, and while it is possible to check exactly
which member a specific user should be connected to, it is tedious and
requires the admin to memorize database primary keys.

Adding this `__str__` methods to the `Member` model will make the list
contain the members' full name instead.

We lose a bit of exactness here, in case we happen to have active
members with identical names. I'm not sure how big of an issue that is,
though.

---

To be a bit more graphical, this is how it will start to look with these changes:

Before:

![image](https://user-images.githubusercontent.com/2308/99890062-b7122d80-2c5b-11eb-8512-5ea2b324c4bf.png)

After:

![image](https://user-images.githubusercontent.com/2308/99890046-9053f700-2c5b-11eb-9502-4741248c24b4.png)
