### PR TITLE
Send any template and various tweaks

### DIFF
--- a/finger/models.py
+++ b/finger/models.py
@@ -349,6 +349,15 @@ class Member(models.Model):
     def joined_years_ago(self):
         return timezone.now().year - self.date_joined.year
 
+    def get_emails(self):
+        ret = []
+        if self.email:
+            ret.append(f"{self.get_full_name()} <{self.email}>")
+        user = User.objects.filter(member=self.id)
+        if user and user.count() < 2:
+            ret.append(f"{self.get_full_name()} <{user[0].username}@stacken.kth.se>")
+        return list(set(ret))
+
     def __repr__(self):
         return f"<Member: {self.get_full_name()} ({self.pk})>"
 

--- a/finger/templates/admin/send_email_confirmation.html
+++ b/finger/templates/admin/send_email_confirmation.html
@@ -9,13 +9,24 @@
 </p>
 
 <ul>
-{% for member in members %}
-<li>{{ member.email }}</li>
-{% endfor %}
+    {% for member in members %}
+        {% for email in member.get_emails %}
+            <li>{{ email }}</li>
+        {% empty %}
+            <li><em>{{ member.get_full_name }} has no email address</em></li>
+        {% endfor %}
+    {% endfor %}
 </ul>
 
 <div>
-    <form action="" method="post">
+    <label for="template">Choose a template:</label>
+    <select name="template" id="template" form="mailform">
+    {% for template in templates %}
+      <option value="{{ template.name }}">{{ template.name }}</option>
+    {% endfor %}
+    </select>
+
+    <form action="" method="post" id="mailform">
         {% csrf_token %}
         {% for member in members %}
         <input type="hidden" name="_selected_action" value="{{ member.pk }}" />
@@ -24,4 +35,12 @@
         <input type="submit" name="apply" value="Confirm" />
     </form>
 </div>
+
+<h2>Templates</h2>
+
+{% for template in templates %}
+<h3>{{ template.name }}</h3>
+{{ template.content }}
+{% endfor %}
+
 {% endblock %}


### PR DESCRIPTION
Update email confirmation page to include a template selector. Also
rename "Send Welcome E-mail" to "Send E-mail" in the dropdown to reflect
the now more generic use.

Also send email to user@stacken.kth.se, is the member has a user. Also
include the full name in the email for nicer rendering.

Set the sender to the logged in user, and set the name to the classic
"Datorföreningen Stacken via ..." message that send.py used.