### PR TITLE
Use python:3.10-slim as base image instead of python:3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Launch a build container so we do not need to care about junk in the production image
 #
-FROM python:3.10 AS build
+FROM python:3.10-slim AS build
 
 # This is needed to start the Django app
 ARG SECRET_KEY=none
@@ -10,7 +10,7 @@ ARG DATABASE_URL=sqlite:///db.sqlite3
 
 # Install sass
 RUN apt-get update
-RUN apt-get -y install ruby-sass
+RUN apt-get -y install ruby-sass build-essential postgresql-client
 
 # Deploy files and install requirements
 ADD app/requirements.txt /app/requirements.txt
@@ -34,13 +34,13 @@ RUN rm db.sqlite3
 #
 # The production container
 #
-FROM python:3.10
+FROM python:3.10-slim
 EXPOSE 8080
 
 RUN adduser --no-create-home --gecos FALSE --disabled-password finger
 
 RUN apt-get update \
-	&& apt-get -y install nginx ruby-sass \
+	&& apt-get -y install nginx ruby-sass postgresql-client \
 	&& rm -rf /var/lib/apt/lists/*
 
 COPY --from=build --chown=finger /app /app

--- a/app/fingerweb/settings.py
+++ b/app/fingerweb/settings.py
@@ -131,7 +131,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en-gb"
 
-TIME_ZONE = "CET"
+TIME_ZONE = "Europe/Stockholm"
 
 USE_I18N = True
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -7,6 +7,6 @@ django-static-precompiler ~= 1.8.2
 markdown ~= 3.1.1
 gunicorn ~= 19.9.0
 django-environ ~= 0.4.5
-psycopg2-binary ~= 2.8.3
+psycopg2-binary ~= 2.9.11
 python-dateutil ~= 2.8.0
 django-post_office ~= 3.5.2


### PR DESCRIPTION
This will shrink the size of the resulting image significantly, because the `python:3.10` image is _chunky_ compared to its `-slim` sibling.

In the `master` branch currently, the image is around 1.2 GB, while this
build clocks in at 300MB. See details below:

```
$ docker image ls|grep --color=never git.stacken.kth.se/stacken/fingerweb
git.stacken.kth.se/stacken/fingerweb   python-slim   76804258796a   4 minutes ago    300MB
git.stacken.kth.se/stacken/fingerweb   master        ecff86210fea   29 minutes ago   1.2GB
```

The image in `master`:

```
% docker image history git.stacken.kth.se/stacken/fingerweb:master
IMAGE          CREATED          CREATED BY                                      SIZE      COMMENT
ecff86210fea   32 minutes ago   CMD ["/bin/sh" "-c" "/app/entrypoint.sh"]       0B        buildkit.dockerfile.v0
<missing>      32 minutes ago   ADD entrypoint.sh /app/entrypoint.sh # build…   310B      buildkit.dockerfile.v0
<missing>      32 minutes ago   ADD conf/nginx.conf /etc/nginx/nginx.conf # …   728B      buildkit.dockerfile.v0
<missing>      32 minutes ago   RUN /bin/sh -c sed -i "s/XXX_BUILD_DATE_XXX/…   4.17kB    buildkit.dockerfile.v0
<missing>      32 minutes ago   WORKDIR /app                                    0B        buildkit.dockerfile.v0
<missing>      32 minutes ago   RUN /bin/sh -c pip install -r /app/requireme…   50.2MB    buildkit.dockerfile.v0
<missing>      32 minutes ago   COPY --chown=finger /app /app # buildkit        1.45MB    buildkit.dockerfile.v0
<missing>      33 hours ago     RUN /bin/sh -c apt-get update  && apt-get -y…   57.3MB    buildkit.dockerfile.v0
<missing>      33 hours ago     RUN /bin/sh -c adduser --no-create-home --ge…   4.49kB    buildkit.dockerfile.v0
<missing>      33 hours ago     EXPOSE map[8080/tcp:{}]                         0B        buildkit.dockerfile.v0
<missing>      2 weeks ago      CMD ["python3"]                                 0B        buildkit.dockerfile.v0
<missing>      2 weeks ago      RUN /bin/sh -c set -eux;  for src in idle3 p…   36B       buildkit.dockerfile.v0
<missing>      2 weeks ago      RUN /bin/sh -c set -eux;   wget -O python.ta…   55.7MB    buildkit.dockerfile.v0
<missing>      2 weeks ago      ENV PYTHON_SHA256=de6517421601e39a9a3bc3e1bc…   0B        buildkit.dockerfile.v0
<missing>      2 weeks ago      ENV PYTHON_VERSION=3.10.20                      0B        buildkit.dockerfile.v0
<missing>      2 weeks ago      ENV GPG_KEY=A035C8C19219BA821ECEA86B64E628F8…   0B        buildkit.dockerfile.v0
<missing>      2 weeks ago      RUN /bin/sh -c set -eux;  apt-get update;  a…   17.8MB    buildkit.dockerfile.v0
<missing>      2 weeks ago      ENV LANG=C.UTF-8                                0B        buildkit.dockerfile.v0
<missing>      2 weeks ago      ENV PATH=/usr/local/bin:/usr/local/sbin:/usr…   0B        buildkit.dockerfile.v0
<missing>      2 weeks ago      RUN /bin/sh -c set -ex;  apt-get update;  ap…   656MB     buildkit.dockerfile.v0
<missing>      2 weeks ago      RUN /bin/sh -c set -eux;  apt-get update;  a…   185MB     buildkit.dockerfile.v0
<missing>      2 weeks ago      RUN /bin/sh -c set -eux;  apt-get update;  a…   60.2MB    buildkit.dockerfile.v0
<missing>      2 weeks ago      # debian.sh --arch 'amd64' out/ 'trixie' '@1…   120MB     debuerreotype 0.17
```

The image for this commit:

```
% docker image history git.stacken.kth.se/stacken/fingerweb:python-slim
IMAGE          CREATED         CREATED BY                                      SIZE      COMMENT
76804258796a   6 minutes ago   CMD ["/bin/sh" "-c" "/app/entrypoint.sh"]       0B        buildkit.dockerfile.v0
<missing>      6 minutes ago   ADD entrypoint.sh /app/entrypoint.sh # build…   310B      buildkit.dockerfile.v0
<missing>      6 minutes ago   ADD conf/nginx.conf /etc/nginx/nginx.conf # …   728B      buildkit.dockerfile.v0
<missing>      6 minutes ago   RUN /bin/sh -c sed -i "s/XXX_BUILD_DATE_XXX/…   4.17kB    buildkit.dockerfile.v0
<missing>      6 minutes ago   WORKDIR /app                                    0B        buildkit.dockerfile.v0
<missing>      6 minutes ago   RUN /bin/sh -c pip install -r /app/requireme…   63.8MB    buildkit.dockerfile.v0
<missing>      7 minutes ago   COPY --chown=finger /app /app # buildkit        1.45MB    buildkit.dockerfile.v0
<missing>      8 minutes ago   RUN /bin/sh -c apt-get update  && apt-get -y…   113MB     buildkit.dockerfile.v0
<missing>      2 hours ago     RUN /bin/sh -c adduser --no-create-home --ge…   4.45kB    buildkit.dockerfile.v0
<missing>      2 hours ago     EXPOSE map[8080/tcp:{}]                         0B        buildkit.dockerfile.v0
<missing>      2 weeks ago     CMD ["python3"]                                 0B        buildkit.dockerfile.v0
<missing>      2 weeks ago     RUN /bin/sh -c set -eux;  for src in idle3 p…   36B       buildkit.dockerfile.v0
<missing>      2 weeks ago     RUN /bin/sh -c set -eux;   savedAptMark="$(a…   39.4MB    buildkit.dockerfile.v0
<missing>      2 weeks ago     ENV PYTHON_SHA256=de6517421601e39a9a3bc3e1bc…   0B        buildkit.dockerfile.v0
<missing>      2 weeks ago     ENV PYTHON_VERSION=3.10.20                      0B        buildkit.dockerfile.v0
<missing>      2 weeks ago     ENV GPG_KEY=A035C8C19219BA821ECEA86B64E628F8…   0B        buildkit.dockerfile.v0
<missing>      2 weeks ago     RUN /bin/sh -c set -eux;  apt-get update;  a…   3.81MB    buildkit.dockerfile.v0
<missing>      2 weeks ago     ENV LANG=C.UTF-8                                0B        buildkit.dockerfile.v0
<missing>      2 weeks ago     ENV PATH=/usr/local/bin:/usr/local/sbin:/usr…   0B        buildkit.dockerfile.v0
<missing>      2 weeks ago     # debian.sh --arch 'amd64' out/ 'trixie' '@1…   78.6MB    debuerreotype 0.17
```